### PR TITLE
Added a link to Doc Portal to Japanese page

### DIFF
--- a/docs-jp/README.md
+++ b/docs-jp/README.md
@@ -7,8 +7,7 @@
 </table>
 
 
-日本語版の Vitis チュートリアルは、次のサイトで提供されています。
-<br>https://xilinx.github.io/Vitis-Tutorials/master/docs-jp/index.html<br><br>
+最新の日本語版を入手するには、<a href="https://docs.xilinx.com/home">https://docs.xilinx.com/home</a> で「Vitis チュートリアル」を検索してください。2022.1 以前のバージョンについては、<a href="https://xilinx.github.io/Vitis-Tutorials/master/docs-jp/index.html">https://xilinx.github.io/Vitis-Tutorials/master/docs-jp/index.html</a> を参照してください。<br><br>
 内容に相違が生じる場合には原文を優先します。英語版の更新に対応していないことがありますので、日本語版は参考用としてご使用の上、最新情報につきましては、必ず最新英語版 (https://github.com/Xilinx/Vitis-Tutorials) をご参照ください。
 
 <p align="center"><sup>Copyright&copy; 2020-2021 Xilinx</sup></p>


### PR DESCRIPTION
Added a link to Doc Portal for the latest Japanese version. The latest Japanese version is only available through Doc Portal.